### PR TITLE
Bump aiohttp from 3.9.5 to 3.10.11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 asyncio==3.4.3
 aiofiles==23.2.1
-aiohttp==3.9.5
+aiohttp==3.10.11
 numpy==1.26.4
 pillow==10.2.0
 psutil


### PR DESCRIPTION
---
updated-dependencies:
- dependency-name: aiohttp dependency-type: direct:production ...